### PR TITLE
scripts: fix for Darwin

### DIFF
--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-basedir=$(dirname $(dirname $(readlink -fm $0)))
+if [ $(uname -s) = Darwin ]; then
+    basedir=$(dirname $(cd "$(dirname "$0")"; pwd -P))
+else
+    basedir=$(dirname $(dirname $(readlink -fm $0)))
+fi
 
 # retrieve the I2P Java sources, OpenJDK and the Ant build tool
 $basedir/bin/import-packages.sh

--- a/bin/build-launcher.sh
+++ b/bin/build-launcher.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-basedir=$(dirname $(dirname $(readlink -fm $0)))
+if [ $(uname -s) = Darwin ]; then
+    basedir=$(dirname $(cd "$(dirname "$0")"; pwd -P))
+else
+    basedir=$(dirname $(dirname $(readlink -fm $0)))
+fi
 
 source $basedir/bin/java-config.sh
 

--- a/bin/build-original-i2p.sh
+++ b/bin/build-original-i2p.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-basedir=$(dirname $(dirname $(readlink -fm $0)))
+if [ $(uname -s) = Darwin ]; then
+    basedir=$(dirname $(cd "$(dirname "$0")"; pwd -P))
+else
+    basedir=$(dirname $(dirname $(readlink -fm $0)))
+fi
 
 cd $basedir/import
 

--- a/bin/convert-jars-to-modules.sh
+++ b/bin/convert-jars-to-modules.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-basedir=$(dirname $(dirname $(readlink -fm $0)))
+if [ $(uname -s) = Darwin ]; then
+    basedir=$(dirname $(cd "$(dirname "$0")"; pwd -P))
+else
+    basedir=$(dirname $(dirname $(readlink -fm $0)))
+fi
 
 source $basedir/bin/java-config.sh
 

--- a/bin/import-packages.sh
+++ b/bin/import-packages.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-basedir=$(dirname $(dirname $(readlink -fm $0)))
+if [ $(uname -s) = Darwin ]; then
+    basedir=$(dirname $(cd "$(dirname "$0")"; pwd -P))
+else
+    basedir=$(dirname $(dirname $(readlink -fm $0)))
+fi
 
 source $basedir/bin/java-config.sh
 

--- a/bin/java-config.sh
+++ b/bin/java-config.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-basedir=$(dirname $(dirname $(readlink -fm $0)))
+if [ $(uname -s) = Darwin ]; then
+    basedir=$(dirname $(cd "$(dirname "$0")"; pwd -P))
+else
+    basedir=$(dirname $(dirname $(readlink -fm $0)))
+fi
 
 JDK_DOWNLOAD_FILENAME_LINUX=OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz
 JDK_DOWNLOAD_FILENAME_MAC=OpenJDK11U-jdk_x64_mac_hotspot_11.0.1_13.tar.gz

--- a/resources/launch.sh
+++ b/resources/launch.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-basedir=$(dirname $(dirname $(readlink -fm $0)))
+if [ $(uname -s) = Darwin ]; then
+    basedir=$(dirname $(cd "$(dirname "$0")"; pwd -P))
+else
+    basedir=$(dirname $(dirname $(readlink -fm $0)))
+fi
 
 $basedir/bin/java -cp $basedir/i2p.base/jbigi.jar -m org.getmonero.i2p.zero --i2p.dir.base=$basedir/i2p.base --i2p.dir.config=$basedir/i2p.config


### PR DESCRIPTION
Note that `readlink -f` is only available with GNU readlink, so on Mac, you have to install Homebrew/MacPorts coreutils and mess around to get the shell to use the GNU readlink. This patch avoids these shenanigans (at least on Darwin for now).

To fix for other BSD's, the `uname -s` test will need expanding, or better yet, drop needing GNU readlink altogether.