### PR TITLE
Includable NSIS installer script and example

### DIFF
--- a/bin/i2p-zero.nsi
+++ b/bin/i2p-zero.nsi
@@ -19,6 +19,7 @@ function buildZero
 	!system "chmod +x build-docker.sh"
 	!system ./build-docker.sh
 	!system "unzip dist-zip/i2p-zero-win-gui.*.zip"
+	!system "rm -rf I2P-Zero"
 	!system "mv i2p-zero-win-gui.* I2P-Zero"
 functionEnd
 
@@ -33,9 +34,6 @@ function installZero
 
 		CreateShortcut "$SMPROGRAMS\Run I2P-Zero.lnk" "$ZEROINSTDIR\router\i2p-zero.exe"
 	${EndIf}
-
-
-
 
 functionEnd
 

--- a/bin/i2p-zero.nsi
+++ b/bin/i2p-zero.nsi
@@ -24,9 +24,9 @@ functionEnd
 
 function installZero
 	${If} ${FileExists} `$I2P64INSTDIR\I2P.exe`
-
+		SetOutPath $ZEROINSTDIR
 	${If} ${FileExists} `$I2P32INSTDIR\I2P.exe`
-
+		SetOutPath $ZEROINSTDIR
 	${Else}
 		SetOutPath $ZEROINSTDIR
 		File /a /r "./I2P-Zero/"

--- a/bin/i2p-zero.nsi
+++ b/bin/i2p-zero.nsi
@@ -1,0 +1,35 @@
+
+!define ZERONAME "I2P-Zero"
+!define I2PINSTDIR "$PROGRAMFILES64\${APPNAME}\"
+
+function buildZero
+	!system "echo '#! /usr/bin/env sh' > build-docker.sh"
+	!system "echo 'docker rm -f i2p-zero-build' >> build-docker.sh"
+	!system "echo 'docker run -td --name i2p-zero-build --rm ubuntu' >> build-docker.sh"
+	!system "echo 'docker exec -ti i2p-zero-build bash -c ;' >> build-docker.sh"
+	!system "echo '  apt-get update && ' >> build-docker.sh"
+	!system "echo '  apt-get -y install git wget zip unzip && ' >> build-docker.sh"
+	!system "echo '  git clone https://github.com/i2p-zero/i2p-zero.git && ' >> build-docker.sh"
+	!system "echo '  cd i2p-zero && bash bin/build-all-and-zip.sh;' >> build-docker.sh"
+	!system "echo 'docker cp i2p-zero-build:/i2p-zero/dist-zip' ./ >> build-docker.sh"
+	!system "echo 'docker container stop i2p-zero-build' >> build-docker.sh"
+	!system "sed -i $\"s|;|'|g$\" build-docker.sh"
+	!system "chmod +x build-docker.sh"
+	!system ./build-docker.sh
+	!system "unzip dist-zip/i2p-zero-win-gui.*.zip"
+	!system "mv i2p-zero-win-gui.* I2P-Zero"
+functionEnd
+
+function installZero
+	CreateShortcut "$SMPROGRAMS\Run I2P-Zero.lnk" "$I2PINSTDIR\router\i2p-zero.exe"
+
+	SetOutPath $I2PINSTDIR
+	File /a /r "./I2P-Zero/"
+
+functionEnd
+
+function uninstallZero
+	Delete "$SMPROGRAMS\Run I2P-Zero.lnk"
+	RMDir $INSTDIR
+
+functionEnd

--- a/bin/i2p-zero.nsi
+++ b/bin/i2p-zero.nsi
@@ -1,6 +1,8 @@
 
 !define ZERONAME "I2P-Zero"
-!define I2PINSTDIR "$PROGRAMFILES64\${APPNAME}\"
+!define I2P64INSTDIR "$PROGRAMFILES64\I2P\"
+!define I2P32INSTDIR "$PROGRAMFILES32\I2P\"
+!define ZEROINSTDIR "$PROGRAMFILES64\${APPNAME}\"
 
 function buildZero
 	!system "echo '#! /usr/bin/env sh' > build-docker.sh"
@@ -21,10 +23,19 @@ function buildZero
 functionEnd
 
 function installZero
-	CreateShortcut "$SMPROGRAMS\Run I2P-Zero.lnk" "$I2PINSTDIR\router\i2p-zero.exe"
+	${If} ${FileExists} `$I2P64INSTDIR\I2P.exe`
 
-	SetOutPath $I2PINSTDIR
-	File /a /r "./I2P-Zero/"
+	${If} ${FileExists} `$I2P32INSTDIR\I2P.exe`
+
+	${Else}
+		SetOutPath $ZEROINSTDIR
+		File /a /r "./I2P-Zero/"
+
+		CreateShortcut "$SMPROGRAMS\Run I2P-Zero.lnk" "$ZEROINSTDIR\router\i2p-zero.exe"
+	${EndIf}
+
+
+
 
 functionEnd
 

--- a/bin/nsis-example.nsi
+++ b/bin/nsis-example.nsi
@@ -17,6 +17,7 @@ Page instfiles
 # For removing Start Menu shortcut in Windows 7
 RequestExecutionLevel admin
 
+# Include the i2p-zero.nsi script
 !include i2p-zero.nsi
 
 # start default section

--- a/bin/nsis-example.nsi
+++ b/bin/nsis-example.nsi
@@ -1,0 +1,48 @@
+UniCode true
+
+# define name of installer
+OutFile "../I2P-Zero-installer.exe"
+ 
+# define installation directory
+!define APPNAME "I2P-Zero"
+InstallDir "$PROGRAMFILES64\${APPNAME}\"
+
+!define LICENSE_TITLE "BSD 3-Clause License"
+PageEx license
+	licensetext "${LICENSE_TITLE}"
+	licensedata "../LICENSE"
+PageExEnd
+Page instfiles
+
+# For removing Start Menu shortcut in Windows 7
+RequestExecutionLevel admin
+
+!include i2p-zero.nsi
+
+# start default section
+Section
+
+	# Call the function that builds an I2P-Zero in the current directory
+	Call buildZero
+	# Call the function that installs I2P-Zero
+	Call installZero
+
+	# create the uninstaller
+	WriteUninstaller "$INSTDIR\uninstall.exe"
+# end default section
+SectionEnd
+
+# uninstaller section start
+Section "uninstall"
+
+	# Call the function that un-installs I2P-Zero
+	Call uninstallZero
+
+	# first, delete the uninstaller
+	Delete "$INSTDIR\uninstall.exe"
+
+	Delete "$SMPROGRAMS\Run I2P-Zero.lnk"
+
+	RMDir $INSTDIR
+# uninstaller section end
+SectionEnd


### PR DESCRIPTION
This adds an NSIS script to the bin directory, `i2p-zero.nsi`. NSIS is the Nullsoft Scriptable Installer System, it's commonly used by Windows packagers to build step-by-step installers. `i2p-zero.nsi` is designed to be "includeable" so that other projects can build and install an I2P-Zero router as part of their Windows installers if another I2P router is not already present. It should be usable from any Unix system where the user has permission to talk to the docker socket. An example "inclusion" via an NSIS installer is also provided. It shows how adding 4 lines to your NSIS installer, you can now install I2P-Zero alongside your I2P-enabled application.