### PR TITLE
Fix router.config dir usage

### DIFF
--- a/org.getmonero.i2p.zero/src/org/getmonero/i2p/zero/RouterWrapper.java
+++ b/org.getmonero.i2p.zero/src/org/getmonero/i2p/zero/RouterWrapper.java
@@ -45,13 +45,20 @@ public class RouterWrapper {
     routerProperties.put("i2p.dir.config", System.getProperty("user.home") + File.separator + ".i2p-zero" + File.separator + "config");
 
     i2PConfigDir = new File(routerProperties.getProperty("i2p.dir.config"));
-    if(!i2PConfigDir.exists()) i2PConfigDir.mkdirs();
+    boolean createdConfigDir = false;
+    if(!i2PConfigDir.exists()) {
+      i2PConfigDir.mkdirs();
+      createdConfigDir = true;
+    }
 
     i2PBaseDir = new File(routerProperties.getProperty("i2p.dir.base"));
     if(!i2PBaseDir.exists()) {
       i2PBaseDir.mkdirs();
       copyFolderRecursively(Path.of(routerProperties.getProperty("i2p.dir.base.template")), i2PBaseDir.toPath());
     }
+
+    if(createdConfigDir)
+      copyFolderRecursively(i2PBaseDir.toPath().resolve("hosts.txt") , i2PConfigDir.toPath().resolve("hosts.txt"));
   }
 
   public Router getRouter() {
@@ -100,7 +107,7 @@ public class RouterWrapper {
           while(true) {
             if(router.isAlive()) {                  
               try {
-                File routerConfigFile = new File(i2PBaseDir, "router.config");
+                File routerConfigFile = new File(i2PConfigDir, "router.config");
                 if(!(routerConfigFile.exists() && routerConfigFile.canRead())) {
                   Thread.sleep(100);
                   continue;


### PR DESCRIPTION
Not sure this is the right fix, but here's the problem: the port advertised in [this message](https://github.com/i2p-zero/i2p-zero/blob/master/org.getmonero.i2p.zero/src/org/getmonero/i2p/zero/Main.java#L44) (router.externalPort) can be wrong.

Following the code, it turns out we hit [this line](https://github.com/i2p/i2p.i2p/blob/master/router/java/src/net/i2p/router/startup/WorkingDir.java#L263), which makes the router _inconsistently_ use base dir, there's 2 `router.config` files: one in base dir and the other in config dir.
 
IIUC, `router.config` **should** be in config dir, not base dir.

By adding `hosts.txt`, [this call to isSetup](https://github.com/i2p/i2p.i2p/blob/master/router/java/src/net/i2p/router/startup/WorkingDir.java#L198) returns `true`, which in turns will make the router consistently use config dir.

I think another way to explain this is that by adding hosts.txt, we complete the initial config dir setup and I2P doesn't consider it needs migrating a previous installation and fails to do so.
 

